### PR TITLE
command.py: remove pipes import

### DIFF
--- a/canto_curses/command.py
+++ b/canto_curses/command.py
@@ -14,7 +14,6 @@ import traceback
 import logging
 import curses
 import shlex
-import pipes
 
 import readline
 


### PR DESCRIPTION
the usage of pipes got removed with https://github.com/themoken/canto-curses/commit/c6ae73061776ac7ae0d12bcd2e02ca068a8815b4

Closes #57